### PR TITLE
Fix a memory leak in CudaANISymmetryFunctions

### DIFF
--- a/ani/CudaANISymmetryFunctions.cu
+++ b/ani/CudaANISymmetryFunctions.cu
@@ -76,6 +76,8 @@ CudaANISymmetryFunctions::~CudaANISymmetryFunctions() {
         cudaFree(positions);
     if (neighbors != 0)
         cudaFree(neighbors);
+    if (neighborCount != 0)
+        cudaFree(neighborCount);
     if (periodicBoxVectors != 0)
         cudaFree(periodicBoxVectors);
     if (angularIndex != 0)


### PR DESCRIPTION
`CudaANISymmetryFunctions::neighborCount` is allocated in the constructor, but nowhere deallocated.