### PR TITLE
mdtraj xyz unit

### DIFF
--- a/ani/BenchmarkCudaANISymmetryFunctions.cu
+++ b/ani/BenchmarkCudaANISymmetryFunctions.cu
@@ -6,6 +6,8 @@
 #include <stdexcept>
 #include <string>
 #include <vector>
+#include <stdio.h>
+#include <time.h>
 
 using namespace std;
 
@@ -149,7 +151,14 @@ int main(int argc, char* argv[]) {
             {12.5, 3.1625, 14.1, 2.74889}
         };
         CudaANISymmetryFunctions ani(species.size(), 7, 5.1, 3.5, periodicBoxVectors.size() > 0, species, radialFunctions, angularFunctions, true);
+        clock_t start, finish;
+        double duration;
+        start = clock();
         runBenchmark(ani, stoi(argv[2]), positions, species, periodicBoxVectors);
+        finish = clock();
+        duration = (double)(finish - start) / CLOCKS_PER_SEC;
+        printf("  %f s\n", duration);
+        printf("  %f ms/it\n", duration/stoi(argv[2])*1000);
     }
     catch (const exception& e) {
         cout << e.what() << endl;

--- a/pytorch/BenchmarkTorchANISymmetryFunctions.py
+++ b/pytorch/BenchmarkTorchANISymmetryFunctions.py
@@ -9,7 +9,7 @@ device = torch.device('cuda')
 
 mol = mdtraj.load('molecules/2iuz_ligand.mol2')
 species = torch.tensor([[atom.element.atomic_number for atom in mol.top.atoms]], device=device)
-positions = torch.tensor(mol.xyz, dtype=torch.float32, requires_grad=True, device=device)
+positions = torch.tensor(mol.xyz * 10, dtype=torch.float32, requires_grad=True, device=device)
 
 nnp = torchani.models.ANI2x(periodic_table_index=True, model_index=None).to(device)
 speciesPositions = nnp.species_converter((species, positions))

--- a/pytorch/README.md
+++ b/pytorch/README.md
@@ -20,7 +20,7 @@ device = torch.device('cuda')
 # Load a molecule
 molecule = mdtraj.load('molecule.mol2')
 species = torch.tensor([[atom.element.atomic_number for atom in molecule.top.atoms]], device=device)
-positions = torch.tensor(molecule.xyz, dtype=torch.float32, requires_grad=True, device=device)
+positions = torch.tensor(molecule.xyz * 10, dtype=torch.float32, requires_grad=True, device=device)
 
 # Construct ANI-2x and replace its native featurizer with NNPOps implementation
 nnp = torchani.models.ANI2x(periodic_table_index=True).to(device)

--- a/pytorch/SymmetryFunctions.py
+++ b/pytorch/SymmetryFunctions.py
@@ -48,7 +48,7 @@ class TorchANISymmetryFunctions(torch.nn.Module):
         # Load a molecule
         >>> molecule = mdtraj.load('molecule.mol2')
         >>> species = torch.tensor([[atom.element.atomic_number for atom in molecule.top.atoms]], device=device)
-        >>> positions = torch.tensor(molecule.xyz, dtype=torch.float32, requires_grad=True, device=device)
+        >>> positions = torch.tensor(molecule.xyz * 10, dtype=torch.float32, requires_grad=True, device=device)
 
         # Construct ANI-2x and replace its native featurizer with NNPOps implementation
         >>> nnp = torchani.models.ANI2x(periodic_table_index=True).to(device)

--- a/pytorch/TestSymmetryFunctions.py
+++ b/pytorch/TestSymmetryFunctions.py
@@ -37,7 +37,7 @@ def test_compare_with_native(deviceString, molFile):
 
     mol = mdtraj.load(f'molecules/{molFile}_ligand.mol2')
     atomicNumbers = torch.tensor([[atom.element.atomic_number for atom in mol.top.atoms]], device=device)
-    atomicPositions = torch.tensor(mol.xyz, dtype=torch.float32, requires_grad=True, device=device)
+    atomicPositions = torch.tensor(mol.xyz * 10, dtype=torch.float32, requires_grad=True, device=device)
 
     nnp = torchani.models.ANI2x(periodic_table_index=True).to(device)
     energy_ref = nnp((atomicNumbers, atomicPositions)).energies
@@ -64,7 +64,7 @@ def test_model_serialization(deviceString, molFile):
 
     mol = mdtraj.load(f'molecules/{molFile}_ligand.mol2')
     atomicNumbers = torch.tensor([[atom.element.atomic_number for atom in mol.top.atoms]], device=device)
-    atomicPositions = torch.tensor(mol.xyz, dtype=torch.float32, requires_grad=True, device=device)
+    atomicPositions = torch.tensor(mol.xyz * 10, dtype=torch.float32, requires_grad=True, device=device)
 
     nnp_ref = torchani.models.ANI2x(periodic_table_index=True).to(device)
     nnp_ref.aev_computer = TorchANISymmetryFunctions(nnp_ref.aev_computer)


### PR DESCRIPTION
The mdtraj's xyz unit seems not in angstrom.
For example, a line in `2iuz_ligand.mol2`, mdtraj will give it position as [ 9.5347,  6.6904, -0.6262]
```
1 O6         95.3475   66.9041   -6.2620 zf         1 D1H     -0.627500
```

This PR is to fix this issue by multiply `mol.xyz` with 10.
Also add timing in BenchmarkCudaANISymmetryFunctions.cu 