### PR TITLE
Fixed errors installing with pip

### DIFF
--- a/src/pyproject.toml
+++ b/src/pyproject.toml
@@ -9,7 +9,7 @@ classifiers = [
   "Programming Language :: Python :: 3",
   "Operating System :: POSIX :: Linux",
 ]
-dependencies = ["torch==2.5.1.*"]
+dependencies = ["torch"]
 
 
 [project.urls]
@@ -26,5 +26,5 @@ include-package-data = false
 NNPOps = "pytorch"
 
 [build-system]
-requires = ["setuptools>=64", "setuptools-scm>=8", "torch==2.5.1.*"]
+requires = ["setuptools>=64", "setuptools-scm>=8", "torch"]
 build-backend = "setuptools.build_meta"

--- a/src/pytorch/OptimizedTorchANI.py
+++ b/src/pytorch/OptimizedTorchANI.py
@@ -32,9 +32,7 @@ from NNPOps.SymmetryFunctions import TorchANISymmetryFunctions
 
 class OptimizedTorchANI(torch.nn.Module):
 
-    from torchani.models import BuiltinModel # https://github.com/openmm/NNPOps/issues/44
-
-    def __init__(self, model: BuiltinModel, atomicNumbers: Tensor) -> None:
+    def __init__(self, model, atomicNumbers: Tensor) -> None:
 
         super().__init__()
 

--- a/src/setup.py
+++ b/src/setup.py
@@ -26,7 +26,7 @@ def set_torch_cuda_arch_list():
     if use_cuda and not os.environ.get("TORCH_CUDA_ARCH_LIST"):
         arch_flags = torch._C._cuda_getArchFlags()
         sm_versions = [x[3:] for x in arch_flags.split() if x.startswith("sm_")]
-        formatted_versions = ";".join([f"{y[0]}.{y[1]}" for y in sm_versions])
+        formatted_versions = ";".join([f"{y[:-1]}.{y[-1]}" for y in sm_versions])
         formatted_versions += "+PTX"
         os.environ["TORCH_CUDA_ARCH_LIST"] = formatted_versions
 


### PR DESCRIPTION
This fixes two errors from #125.  First, it hardcoded a specific version of PyTorch.  Second, it processed CUDA architecture versions incorrectly.  I also fixed a bug that caused `import NNPOps` to fail if torchani wasn't installed.