### PR TITLE
Remove TorchANI imports for type annotations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,33 +22,25 @@ jobs:
       matrix:
         include:
 
-          # # Oldest supported versions
-          # - name: Linux (CUDA 11.8, Python 3.10, PyTorch 2.0)
-          #   enable_cuda: true
-          #   cuda: "11.8.0"
-          #   gcc: "10.3.*"
-          #   nvcc: "11.8"
-          #   python: "3.10.*"
-          #   torchani: "2.2.*"
-          #   pytorch: "2.0.*"
-
-          # # Latest supported versions (with CUDA)
-          # - name: Linux (CUDA 12, Python 3.13, PyTorch 2.5)
-          #   enable_cuda: true
-          #   cuda: "12.6.0"
-          #   gcc: "10.3.*"
-          #   nvcc: "12.*"
-          #   python: "3.13.*"
-          #   torchani: "2.2.*"
-          #   pytorch: "2.5.*"
-          - name: Linux (CUDA 12, Python 3.13, PyTorch 2.9)
+          # Oldest supported versions
+          - name: Linux (CUDA 11.8, Python 3.10, PyTorch 2.0)
             enable_cuda: true
-            cuda: "12.9.0"
+            cuda: "11.8.0"
             gcc: "10.3.*"
-            nvcc: "12.9"
-            python: "3.*"
+            nvcc: "11.8"
+            python: "3.10.*"
             torchani: "2.2.*"
-            pytorch: "2.9.*"
+            pytorch: "2.0.*"
+
+          # Latest supported versions (with CUDA)
+          - name: Linux (CUDA 12, Python 3.13, PyTorch >=2.0)
+            enable_cuda: true
+            cuda: "12.6.0"
+            gcc: "10.3.*"
+            nvcc: "12.*"
+            python: "3.13.*"
+            torchani: "2.2.*"
+            pytorch: "2.*"
 
     steps:
     - name: Check out
@@ -58,7 +50,7 @@ jobs:
       uses: jlumbroso/free-disk-space@main
 
     - name: Install CUDA Toolkit
-      uses: Jimver/cuda-toolkit@v0.2.29
+      uses: Jimver/cuda-toolkit@v0.2.21
       with:
         cuda: ${{ matrix.cuda }}
         linux-local-args: '["--toolkit", "--override"]'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
             enable_cuda: true
             cuda: "12.9.0"
             gcc: "10.3.*"
-            nvcc: "12.*"
+            nvcc: "12.9"
             python: "3.*"
             torchani: "2.2.*"
             pytorch: "2.9.*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,14 @@ jobs:
             python: "3.13.*"
             torchani: "2.2.*"
             pytorch: "2.5.*"
+          - name: Linux (CUDA 12, Python 3.13, PyTorch 2.9)
+            enable_cuda: true
+            cuda: "12.6.0"
+            gcc: "10.3.*"
+            nvcc: "12.*"
+            python: "3.13.*"
+            torchani: "2.2.*"
+            pytorch: "2.9.*"
 
     steps:
     - name: Check out

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
             pytorch: "2.5.*"
           - name: Linux (CUDA 12, Python 3.13, PyTorch 2.9)
             enable_cuda: true
-            cuda: "12.*"
+            cuda: "12.6.0"
             gcc: "10.3.*"
             nvcc: "12.*"
             python: "3.*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,25 +22,25 @@ jobs:
       matrix:
         include:
 
-          # Oldest supported versions
-          - name: Linux (CUDA 11.8, Python 3.10, PyTorch 2.0)
-            enable_cuda: true
-            cuda: "11.8.0"
-            gcc: "10.3.*"
-            nvcc: "11.8"
-            python: "3.10.*"
-            torchani: "2.2.*"
-            pytorch: "2.0.*"
+          # # Oldest supported versions
+          # - name: Linux (CUDA 11.8, Python 3.10, PyTorch 2.0)
+          #   enable_cuda: true
+          #   cuda: "11.8.0"
+          #   gcc: "10.3.*"
+          #   nvcc: "11.8"
+          #   python: "3.10.*"
+          #   torchani: "2.2.*"
+          #   pytorch: "2.0.*"
 
-          # Latest supported versions (with CUDA)
-          - name: Linux (CUDA 12, Python 3.13, PyTorch 2.5)
-            enable_cuda: true
-            cuda: "12.6.0"
-            gcc: "10.3.*"
-            nvcc: "12.*"
-            python: "3.13.*"
-            torchani: "2.2.*"
-            pytorch: "2.5.*"
+          # # Latest supported versions (with CUDA)
+          # - name: Linux (CUDA 12, Python 3.13, PyTorch 2.5)
+          #   enable_cuda: true
+          #   cuda: "12.6.0"
+          #   gcc: "10.3.*"
+          #   nvcc: "12.*"
+          #   python: "3.13.*"
+          #   torchani: "2.2.*"
+          #   pytorch: "2.5.*"
           - name: Linux (CUDA 12, Python 3.13, PyTorch 2.9)
             enable_cuda: true
             cuda: "12.6.0"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
           #   pytorch: "2.5.*"
           - name: Linux (CUDA 12, Python 3.13, PyTorch 2.9)
             enable_cuda: true
-            cuda: "12.6.0"
+            cuda: "12.9.0"
             gcc: "10.3.*"
             nvcc: "12.*"
             python: "3.*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,10 +43,10 @@ jobs:
             pytorch: "2.5.*"
           - name: Linux (CUDA 12, Python 3.13, PyTorch 2.9)
             enable_cuda: true
-            cuda: "12.6.0"
+            cuda: "12.*"
             gcc: "10.3.*"
             nvcc: "12.*"
-            python: "3.13.*"
+            python: "3.*"
             torchani: "2.2.*"
             pytorch: "2.9.*"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
       uses: jlumbroso/free-disk-space@main
 
     - name: Install CUDA Toolkit
-      uses: Jimver/cuda-toolkit@v0.2.21
+      uses: Jimver/cuda-toolkit@v0.2.29
       with:
         cuda: ${{ matrix.cuda }}
         linux-local-args: '["--toolkit", "--override"]'

--- a/src/pytorch/BatchedNN.py
+++ b/src/pytorch/BatchedNN.py
@@ -36,9 +36,7 @@ class SpeciesEnergies(NamedTuple):
 
 class _BatchedNN(torch.nn.Module):
 
-    from torchani.nn import ANIModel, Ensemble, SpeciesConverter # https://github.com/openmm/NNPOps/issues/44
-
-    def __init__(self, converter: SpeciesConverter, ensemble: Union[ANIModel, Ensemble], atomicNumbers: Tensor):
+    def __init__(self, converter, ensemble, atomicNumbers: Tensor):
 
         super().__init__()
 
@@ -113,9 +111,7 @@ class _BatchedNN(torch.nn.Module):
 
 class TorchANIBatchedNN(torch.nn.ModuleList):
 
-    from torchani.nn import ANIModel, Ensemble, SpeciesConverter # https://github.com/openmm/NNPOps/issues/44
-
-    def __init__(self, converter: SpeciesConverter, ensemble: Union[ANIModel, Ensemble], atomicNumbers: Tensor):
+    def __init__(self, converter, ensemble, atomicNumbers: Tensor):
         super().__init__([_BatchedNN(converter, ensemble, atomicNumbers)])
 
     def forward(self, species_aev: Tuple[Tensor, Tensor]) -> SpeciesEnergies:

--- a/src/pytorch/EnergyShifter.py
+++ b/src/pytorch/EnergyShifter.py
@@ -31,10 +31,7 @@ class SpeciesEnergies(NamedTuple):
 
 class TorchANIEnergyShifter(torch.nn.Module):
 
-    from torchani.nn import SpeciesConverter # https://github.com/openmm/NNPOps/issues/44
-    from torchani.utils import EnergyShifter # https://github.com/openmm/NNPOps/issues/44
-
-    def __init__(self, converter: SpeciesConverter, shifter: EnergyShifter, atomicNumbers: Tensor) -> None:
+    def __init__(self, converter, shifter, atomicNumbers: Tensor) -> None:
 
         super().__init__()
 

--- a/src/pytorch/SpeciesConverter.py
+++ b/src/pytorch/SpeciesConverter.py
@@ -23,9 +23,7 @@ class SpeciesCoordinates(NamedTuple):
 
 class TorchANISpeciesConverter(torch.nn.Module):
 
-    from torchani.nn import SpeciesConverter
-
-    def __init__(self, converter: SpeciesConverter, atomicNumbers: Tensor) -> None:
+    def __init__(self, converter, atomicNumbers: Tensor) -> None:
 
         super().__init__()
 

--- a/src/pytorch/SymmetryFunctions.py
+++ b/src/pytorch/SymmetryFunctions.py
@@ -60,10 +60,7 @@ class TorchANISymmetryFunctions(torch.nn.Module):
         >>> print(energy, forces)
     """
 
-    from torchani import AEVComputer # https://github.com/openmm/NNPOps/pull/38
-    from torchani import SpeciesConverter # https://github.com/openmm/NNPOps/pull/38
-
-    def __init__(self, converter: SpeciesConverter, symmFunc: AEVComputer, atomicNumbers: Tensor) -> None:
+    def __init__(self, converter, symmFunc, atomicNumbers: Tensor) -> None:
         """
         Arguments:
             converter: an instance of torchani.nn.SpeciesConverter (https://aiqm.github.io/torchani/api.html#torchani.SpeciesConverter)


### PR DESCRIPTION
Removes some TorchANI imports from classes.  The change suggested in #44 doesn't actually fix the problem since the class bodies get executed whether or not instances are created.  Since these are only used for type annotations, they can be removed, allowing NNPOps to be imported without having TorchANI installed.